### PR TITLE
fix: use JSON

### DIFF
--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
       - run: renovate --version
-      - run: renovate-config-validator default.json5
+      - run: renovate-config-validator default.json

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# renovate-presets
+# renovate-config
 
 Custom [Renovate presets](https://docs.renovatebot.com/config-presets/), add to your renovate config:
 
@@ -6,6 +6,6 @@ Custom [Renovate presets](https://docs.renovatebot.com/config-presets/), add to 
   {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 -   "extends": ["config:base"],
-+   "extends": ["github>statnett/renovate-presets"],
++   "extends": ["github>statnett/renovate-config"],
   }
 ```

--- a/default.json
+++ b/default.json
@@ -1,10 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "",
-  "extends": [
-    "config:base",
-    "regexManagers:dockerfileVersions"
-  ],
+  "extends": ["config:base", "regexManagers:dockerfileVersions"],
   "customManagers": [
     {
       "customType": "regex",
@@ -22,6 +19,6 @@
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
-    },
-  ],
+    }
+  ]
 }


### PR DESCRIPTION
To support [organization level preset](https://docs.renovatebot.com/config-presets/#organization-level-presets), the config name should be `default.json`. I think we make it easier to ourselves to follow the default here. 

Depends on https://github.com/statnett/renovate-config/pull/8