### PR TITLE
ci: trigger validation on pull requests

### DIFF
--- a/.github/workflows/validate-renovate-config.yaml
+++ b/.github/workflows/validate-renovate-config.yaml
@@ -2,7 +2,8 @@
 name: Validate renovate config
 
 on:
-  - push
+  pull_request: {}
+  push: {}
 
 jobs:
   validate-renovate-config:


### PR DESCRIPTION
Pull requests should also have the validation job run, since we have enabled that the validation check must succeed, this PR is necessary for all other PRs to be mergeable:

![image](https://github.com/statnett/renovate-config/assets/104485047/2e85f132-c380-4e51-ac3f-12255fae9fb3)
