### PR TITLE
fix: regex for custom renovate: regex matcher

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,7 @@
       "customType": "regex",
       "fileMatch": [".*"],
       "matchStrings": [
-        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: (packageName)=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\n\\s*(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s"
+        "renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+(package|lookup)Name=(?<packageName>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?(?:\\s+registryUrl=(?<registryUrl>\\S+))?\\n.+?_(?:VERSION|version|TAG|tag)\\s*[?=:]+\\s*\"?(?<currentValue>[^\" \\t\\n]+)\"?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },


### PR DESCRIPTION
After https://github.com/statnett/k3a-lag-exporter/pull/70, we lost the match on https://github.com/statnett/k3a-lag-exporter/blob/main/src/test/java/no/statnett/k3alagexporter/itest/services/Versions.java#L9.

I am not an expert on writing regex, but we need to find a consensus on how this should be. @mikaelol and @sverrehu must agree on something. 😉 