### PR TITLE
fix(regex): better matching of currentValue

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,7 @@
       "customType": "regex",
       "fileMatch": [".*"],
       "matchStrings": [
-        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: (packageName)=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\n\\s*(?:\\S+?_)?(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>\\S+?)\"?\\s"
+        "renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>\\S+?)(?: packageName=(?<packageName>\\S+?))?(?: versioning=(?<versioning>\\S+?))?(?: registryUrl=(?<registryUrl>\\S+?))?\\n.*(?:VERSION|version|TAG|tag)\\s*[?]?[=:]\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     },


### PR DESCRIPTION
Better matching for `currentValue` and add support java markers.

Supersedes https://github.com/statnett/renovate-config/pull/10