### PR TITLE
fix: postUpdateOptions was meant for the inherited config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,10 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ],
-  "postUpdateOptions": [
-    "gomodMassage",
-    "gomodTidy",
-    "gomodUpdateImportPaths"
   ]
 }

--- a/default.json
+++ b/default.json
@@ -20,5 +20,10 @@
       "datasourceTemplate": "docker",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}"
     }
+  ],
+  "postUpdateOptions": [
+    "gomodMassage",
+    "gomodTidy",
+    "gomodUpdateImportPaths"
   ]
 }


### PR DESCRIPTION
I made a mistake in https://github.com/statnett/renovate-config/pull/12, and added the `postUpdateOptions` to THIS PROJECT config, but I wanted to add it to the INHERITED config. This fixes it.

Required to fix the top 3 PRs here: https://github.com/statnett/image-scanner-operator/pulls