### PR TITLE
fix: reset ignorePaths to default

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "",
   "extends": ["config:base", "regexManagers:dockerfileVersions"],
+  "ignorePaths": ["**/node_modules/**", "**/bower_components/**"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
We are extending `config:base` (which, by the way, should [be migrated](https://github.com/statnett/renovate-config/pull/27) to [`config:recommended`](https://docs.renovatebot.com/presets-config/#configrecommended)) in this project, and that preset includes [`:ignoreModulesAndTests`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests), defined as:

```json
{
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ],
  "nuget": {
    "ignorePaths": [
      "**/node_modules/**",
      "**/bower_components/**",
      "**/vendor/**",
      "**/examples/**",
      "**/__fixtures__/**"
    ]
  }
}
```

In downstream projects, we have dependencies in our test folders, e.g., [`test/e2e-config/k3d-config.yml`](https://github.com/mikaelol/image-scanner-operator/blob/e48ccee1ee5af7b9c0ab925557385ea287749994/test/e2e-config/k3d-config.yml#L6-L7), and those are being ignored.

The suggested fix is to override [`ignorePaths`](https://docs.renovatebot.com/configuration-options/#ignorepaths) to the Renovate default: `["**/node_modules/**", "**/bower_components/**"]`.