### PR TITLE
fix: improve group for Go K8s dependencies

### DIFF
--- a/default.json
+++ b/default.json
@@ -34,9 +34,9 @@
   ],
   "packageRules": [
     {
-      "groupName": "Kubernetes",
-      "matchManagers": [
-        "gomod"
+      "groupName": "Kubernetes Go packages",
+      "matchDatasources": [
+        "go"
       ],
       "matchPackageNames": [
         "k8s.io/**",


### PR DESCRIPTION
Still not there, ref. https://github.com/statnett/image-scanner-operator/pulls. I think it's better to match on the datasource in this case, and I also added a bit more context to the group name.