### PR TITLE
chore: only update renovate on Mondays

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["renovate/renovate"],
+      "schedule": [
+        "after 00:00 and before 07:00 on Monday"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
`renovate/renovate` is very frequent in its releases (multiple per day), so to reduce noise we should update this only once a week. 

It will appear in the dependency dashboard, so if we want to update more frequent we can trigger a PR from there.