### PR TITLE
feat: make shared preset use best-practices preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     "customManagers:dockerfileVersions"
   ],
   "ignorePaths": [


### PR DESCRIPTION
My intention in https://github.com/statnett/renovate-config/pull/32 was to change the shared preset. 😆 But I did only change the local preset in this project. This fixes it according to the intention.