### PR TITLE
feat: add labels to PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,7 @@
     "**/node_modules/**",
     "**/bower_components/**"
   ],
+  "labels": ["dependencies"],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Which will make it easier to find Renovate upgrade PRs when browsing PRs on the organization level.