### PR TITLE
feat: enable security updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -3,13 +3,15 @@
   "description": "",
   "extends": [
     "config:best-practices",
-    "customManagers:dockerfileVersions"
+    "customManagers:dockerfileVersions",
+    "security:gomodIndirectSecurityUpdates"
   ],
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**"
   ],
   "labels": ["dependencies"],
+  "osvVulnerabilityAlerts": true,
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Security updates are currently raised by Dependabot, which usually produces wrong conventional commits. Hopefully this change will make Renovate catch more security updates. We've been running with a similar configuration in cert-manager for a while, ref. https://github.com/cert-manager/renovate-config/blob/62bdc6aeecfdb17caacd84812514359e99eb151d/default.json5. I just discovered https://docs.renovatebot.com/presets-security/#securitygomodindirectsecurityupdates - which I will create a PR to use in cert-manager now. Appears better for Go projects.